### PR TITLE
feat: manage chromium download manually with retry as it is flimsy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,9 @@ verify-execution: $(foreach pptr-version,$(or $(puppeteer),"latest"),verify-exec
 
 verify-execution/%:
 	@$(call log-info,"Installing Puppeteer@$(@F)...")
-	@npm install --loglevel error puppeteer@$(@F)
+	@PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install --loglevel error puppeteer@$(@F)
+	@$(call log-info,"Downloading Chromium...")
+	@node ./fixtures/chromium-download.js
 	@$(call log-info,"Testing for successful Puppeteer initialization...")
 	@node ./fixtures/puppeteer-init.js
 	@$(call log-success,"Image have properly configured prerequisites for Puppeteer@$(@F).")

--- a/fixtures/chromium-download.js
+++ b/fixtures/chromium-download.js
@@ -1,0 +1,64 @@
+const cp = require('child_process');
+
+function downloadChromium() {
+  return new Promise((resolve, reject) => {
+    const instance = cp.spawn('node', [require.resolve('puppeteer/install')]);
+    let didResolve = false;
+
+    function handleStdout(data) {
+      const message = data.toString();
+      process.stdout.write(message);
+
+      if (/^Chromium( \([0-9]{6}\))* downloaded to/.test(message)) {
+        if (!didResolve) {
+          didResolve = true;
+          resolve(instance);
+        }
+      }
+    }
+
+    function handleStderr(data) {
+      const message = data.toString();
+      process.stderr.write(message);
+    }
+
+    instance.stdout.on('data', handleStdout);
+    instance.stderr.on('data', handleStderr);
+
+    instance.on('close', () => {
+      instance.stdout.removeListener('data', handleStdout);
+      instance.stderr.removeListener('data', handleStderr);
+
+      if (!didResolve) {
+        didResolve = true;
+        resolve();
+      }
+    });
+
+    instance.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
+
+async function runWithRetry(fn, { currentRetry = 0, delay = 1000, maxRetries = 3 } = {}) {
+  try {
+    return await fn();
+  } catch (error) {
+    if (currentRetry < maxRetries) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, Math.pow(delay, currentRetry + 1));
+      });
+
+      return runWithRetry(fn, {
+        currentRetry: currentRetry + 1,
+        delay,
+        maxRetries,
+      });
+    }
+
+    throw error;
+  }
+}
+
+void runWithRetry(downloadChromium);

--- a/fixtures/chromium-download.js
+++ b/fixtures/chromium-download.js
@@ -18,7 +18,7 @@ async function runWithRetry(
         setTimeout(resolve, delay * Math.pow(backoff, currentRetry + 1));
       });
 
-      console.log('Retrying...')
+      console.log('Retrying...');
       return runWithRetry(fn, {
         backoff,
         currentRetry: currentRetry + 1,

--- a/fixtures/chromium-download.js
+++ b/fixtures/chromium-download.js
@@ -1,11 +1,10 @@
 const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 function downloadChromium() {
   return new Promise((resolve, reject) => {
-    const instance = cp.spawn('node', [
-      '--unhandled-rejections=strict',
-      require.resolve('puppeteer/install'),
-    ]);
+    const instance = cp.spawn('node', [require.resolve('puppeteer/install')]);
     let didResolve = false;
 
     function handleStdout(data) {
@@ -28,7 +27,7 @@ function downloadChromium() {
     instance.stdout.on('data', handleStdout);
     instance.stderr.on('data', handleStderr);
 
-    instance.on('close', (code, signal) => {
+    instance.on('close', (code) => {
       instance.stdout.removeListener('data', handleStdout);
       instance.stderr.removeListener('data', handleStderr);
 
@@ -38,7 +37,12 @@ function downloadChromium() {
           resolve();
         }
       } else {
-        reject(signal);
+        const installPath = path.join(__dirname, '..', 'node_modules/puppeteer/.local-chromium');
+        if (fs.existsSync(installPath)) {
+          fs.rmdirSync(installPath);
+        }
+
+        reject(new Error('Chromium download failed!'));
       }
     });
 

--- a/fixtures/chromium-download.js
+++ b/fixtures/chromium-download.js
@@ -2,6 +2,10 @@ const cp = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+process.on('unhandledRejection', (reason) => {
+  throw reason;
+});
+
 function rmdirRecursive(dirPath) {
   if (fs.existsSync(dirPath)) {
     const files = fs.readdirSync(dirPath);
@@ -69,7 +73,7 @@ function downloadChromium() {
 
 async function runWithRetry(
   fn,
-  { backoff = 2, currentRetry = 0, delay = 100, maxRetries = 3 } = {},
+  { backoff = 2, currentRetry = 0, delay = 100, maxRetries = 3 } = {}
 ) {
   try {
     return await fn();

--- a/fixtures/chromium-download.js
+++ b/fixtures/chromium-download.js
@@ -83,6 +83,7 @@ async function runWithRetry(
         setTimeout(resolve, delay * Math.pow(backoff, currentRetry + 1));
       });
 
+      console.log('Retrying...')
       return runWithRetry(fn, {
         backoff,
         currentRetry: currentRetry + 1,

--- a/fixtures/puppeteer-init.js
+++ b/fixtures/puppeteer-init.js
@@ -1,10 +1,14 @@
 const puppeteer = require('puppeteer');
 
-(async () => {
+process.on('unhandledRejection', (reason) => {
+  throw reason;
+});
+
+async function puppeteerInit() {
   const browser = await puppeteer.launch({
     headless: true,
   });
   await browser.close();
-})().catch((e) => {
-  throw e;
-});
+}
+
+void puppeteerInit();

--- a/fixtures/puppeteer-init.js
+++ b/fixtures/puppeteer-init.js
@@ -5,6 +5,6 @@ const puppeteer = require('puppeteer');
     headless: true,
   });
   await browser.close();
-})().catch(e => {
+})().catch((e) => {
   throw e;
 });

--- a/run.sh
+++ b/run.sh
@@ -114,8 +114,7 @@ function command-test() {
     "${name}:${tag}" bash 1>/dev/null
 
   # Copy fixtures and the Makefile into the container
-  # shellcheck disable=SC2086
-  docker cp ./fixtures/. ${container}:/home/circleci/project/fixtures
+  docker cp ./fixtures/. "${container}":/home/circleci/project/fixtures
   docker cp ./Makefile "${container}":/home/circleci/project/Makefile
 
   # Parse the container's Node.js version
@@ -135,13 +134,16 @@ function command-test() {
     puppeteer_versions+=("3" "4" "5")
   fi
 
+  # Cleanup the spawned container on error or exit
+  function cleanup() {
+    docker kill "${container}" 1>/dev/null
+    docker rm "${container}" 1>/dev/null
+  }
+
+  trap cleanup err exit
+
   # Run tests for all compatible puppeteer versions
   docker exec "${container}" make verify-all puppeteer="${puppeteer_versions[*]}"
-
-  # Cleanup the spawned container
-  docker kill "${container}" 1>/dev/null
-  # shellcheck disable=SC2086
-  docker rm ${container} 1>/dev/null
 }
 
 case $# in

--- a/run.sh
+++ b/run.sh
@@ -106,7 +106,8 @@ function command-test() {
   local name="$1"
   local tag="$2"
 
-  local container="test-${tag}"
+  # This is intentionally global - it will be used by `trap` for cleanup
+  container="test-${tag}"
 
   # Spawn a new container with an interactive shell to keep it alive
   docker run --detach --init --privileged --tty \


### PR DESCRIPTION
Because of how flimsy `puppeteer`'s post-install script is (due to socket/Node.js bugs etc.), we will handle it manually (with exponential back-off retrying) in tests to ensure that installation can complete and the actual environment can be tested.